### PR TITLE
fixed "Open Folder" button not working

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,7 @@ import hytaleLogo from './assets/logo.png';
 
 import { 
   DownloadAndLaunch, 
-  OpenFolder, 
+  OpenGameFolder, 
   GetNick, 
   SetNick, 
   DeleteGame, 
@@ -211,7 +211,7 @@ const App: React.FC = () => {
           downloaded={downloaded}
           total={total}
           actions={{
-            openFolder: OpenFolder,
+            openFolder: OpenGameFolder,
             showDelete: () => setShowDelete(true),
             showModManager: () => setShowModManager(true)
           }}


### PR DESCRIPTION
I fixed the Open Folder button not actually opening the game folder. Function with the wrong name was used in the button. After the changes, it works as expected on my Linux system.

<img width="1918" height="1080" alt="image" src="https://github.com/user-attachments/assets/b04f8edf-4274-45b3-ac0d-adc775f43c23" />
