### PR TITLE
Use `WebviewGpuPolicyNever` option for Linux to fix Wayland crash

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 		},
 		Linux: &linux.Options{
 			WindowIsTranslucent: false,
-			WebviewGpuPolicy:    linux.WebviewGpuPolicyAlways,
+			WebviewGpuPolicy:    linux.WebviewGpuPolicyNever,
 		},
 	})
 


### PR DESCRIPTION
Addresses issue #38