### PR TITLE
Fix DualAuth agent not loading for singleplayer

### DIFF
--- a/Services/Game/Launch/LaunchService.cs
+++ b/Services/Game/Launch/LaunchService.cs
@@ -447,7 +447,7 @@ public class LaunchService : ILaunchService
         return false;
     }
 
-    private const string WrapperVersion = "v3"; // Bump when wrapper content changes
+    private const string WrapperVersion = "v4"; // Bump when wrapper content changes
 
     private void EnsureJavaWrapper(string javaBin)
     {
@@ -523,7 +523,9 @@ public class LaunchService : ILaunchService
                          "  ARGS+=(\"$arg\")\n" +
                          "done\n" +
                          "if $IS_SERVER; then\n" +
-                         "  unset JAVA_TOOL_OPTIONS\n" +
+                         "  if [[ \"$JAVA_TOOL_OPTIONS\" != *\"-javaagent:\"* ]]; then\n" +
+                         "    unset JAVA_TOOL_OPTIONS\n" +
+                         "  fi\n" +
                          "fi\n" +
                          "exec \"$REAL_JAVA\" \"${ARGS[@]}\"\n";
 


### PR DESCRIPTION
## Summary
- The Java wrapper script unconditionally unset JAVA_TOOL_OPTIONS when detecting a server process, stripping the -javaagent flag needed by DualAuth
- Singleplayer embedded servers failed with Token validation failed because the DualAuth agent never loaded to handle F2P token validation
- Now the wrapper preserves JAVA_TOOL_OPTIONS when it contains a -javaagent entry
- Bumped wrapper version to v4 to force regeneration on existing installs